### PR TITLE
preserve sequelize jsonb and handle NUL bytes smrtly

### DIFF
--- a/src/features/courses/course-controller.ts
+++ b/src/features/courses/course-controller.ts
@@ -903,26 +903,26 @@ class CourseController {
             studentGrade.firstAttempts = options.score;
         }
         studentGrade.latestAttempts = options.score;
-        
+
         try {
             return await appSequelize.transaction(async (): Promise<SubmitAnswerResult> => {
                 await studentGrade.save();
-    
+
                 const studentWorkbook = await StudentWorkbook.create({
                     studentGradeId: studentGrade.id,
                     userId: options.userId,
                     courseWWTopicQuestionId: studentGrade.courseWWTopicQuestionId,
                     randomSeed: studentGrade.randomSeed,
-                    submitted: JSON.stringify(options.submitted),
+                    submitted: options.submitted,
                     result: options.score,
                     time: new Date()
                 });
-        
+
                 return {
                     studentGrade,
                     studentWorkbook
-                };    
-            });    
+                };
+            });
         } catch (e) {
             if (e instanceof RederlyExtendedError === false) {
                 throw new WrappedError(e.message, e);

--- a/src/features/courses/course-route.ts
+++ b/src/features/courses/course-route.ts
@@ -192,7 +192,7 @@ router.get('/questions',
                 const user = await req.session.getUser();
                 if (user.roleId === Role.STUDENT) {
                     next(Boom.badRequest(`The topic "${topic.name}" has not started yet.`));
-                    return;    
+                    return;
                 }
             }
         }
@@ -498,7 +498,13 @@ router.post('/question/:id',
 
             let data = proxyResData.toString('utf8');
             try {
-                data = JSON.parse(data);
+                data = JSON.parse(data, (k,v) => {
+                  if (typeof v === 'string' && v.match(/\u0000/)) {
+                    return v.split('\u0000');
+                  } else {
+                    return v;
+                  }
+                });
             } catch (e) {
                 throw new WrappedError('Error parsing data response from renderer', e);
             }

--- a/src/features/courses/course-route.ts
+++ b/src/features/courses/course-route.ts
@@ -498,13 +498,7 @@ router.post('/question/:id',
 
             let data = proxyResData.toString('utf8');
             try {
-                data = JSON.parse(data, (k,v) => {
-                  if (typeof v === 'string' && v.match(/\u0000/)) {
-                    return v.split('\u0000');
-                  } else {
-                    return v;
-                  }
-                });
+                data = JSON.parse(data);
             } catch (e) {
                 throw new WrappedError('Error parsing data response from renderer', e);
             }


### PR DESCRIPTION
I don't like stringify on JSON for the database -- this changes how we parse the renderer result, creating arrays in form_data wherever the original multipart-form/data included repeated keys. It will be much easier to reconstruct the student submission from this structure... and we keep the jsonb-enefits in pg