### PR TITLE
Add docker ignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+ts-built
+logs
+*.DS_Store
+tmp
+build
+package-outputs


### PR DESCRIPTION
This fixes issues when developing and trying to build the docker image
the db driver is os specific and so without ignoring the node_modules
you get a seg fault
Added all other git ignored files (except env) here as well, even though
they don't hurt they slow it down
env needs to stay so that your configurations pass into the container